### PR TITLE
Add alerting and mission creation

### DIFF
--- a/packages/shared/openapi.yaml
+++ b/packages/shared/openapi.yaml
@@ -123,6 +123,144 @@ paths:
               schema:
                 type: array
                 items: { $ref: "#/components/schemas/ResponderCandidate" }
+  /incidents/{incident_id}/alerts:
+    post:
+      summary: Alert nearby responders (dispatcher; manual §9)
+      tags: [alerts]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - { name: incident_id, in: path, required: true, schema: { type: string, format: uuid } }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                alert_type: { type: string }
+                reason: { type: string, nullable: true }
+                verified_only: { type: boolean, default: true }
+                skills: { type: array, items: { type: string } }
+      responses:
+        "201":
+          description: Alert campaign summary
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  incident_id: { type: string, format: uuid }
+                  expiry_at: { type: string, format: date-time }
+                  recipients: { type: integer }
+                  alert_ids: { type: array, items: { type: string, format: uuid } }
+        "422": { description: Missing search area or required reason }
+        "429": { description: Rate limit exceeded }
+  /incidents/{incident_id}/create-mission:
+    post:
+      summary: Create a mission from an incident (dispatcher; manual §5.3)
+      tags: [missions]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - { name: incident_id, in: path, required: true, schema: { type: string, format: uuid } }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                lead_user_id: { type: string, format: uuid, nullable: true }
+                auto_add_accepted: { type: boolean, default: true }
+      responses:
+        "201":
+          description: Created mission
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Mission" }
+  /alerts:
+    get:
+      summary: List the current user's alerts
+      tags: [alerts]
+      security: [{ bearerAuth: [] }]
+      responses:
+        "200":
+          description: Alert inbox
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "#/components/schemas/Alert" }
+  /alerts/{alert_id}/respond:
+    post:
+      summary: Respond to an alert (recipient; manual §9.3)
+      tags: [alerts]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - { name: alert_id, in: path, required: true, schema: { type: string, format: uuid } }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [response]
+              properties:
+                response: { type: string, enum: [yes, no, need_details] }
+      responses:
+        "200":
+          description: Updated alert
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Alert" }
+        "409": { description: Alert has expired }
+  /missions:
+    get:
+      summary: List missions (membership-scoped for non-staff)
+      tags: [missions]
+      security: [{ bearerAuth: [] }]
+      responses:
+        "200":
+          description: Mission collection
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "#/components/schemas/Mission" }
+  /missions/{mission_id}:
+    get:
+      summary: Get a mission
+      tags: [missions]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - { name: mission_id, in: path, required: true, schema: { type: string, format: uuid } }
+      responses:
+        "200":
+          description: Mission
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Mission" }
+        "403": { description: Not a mission member }
+    patch:
+      summary: Update mission status (staff or Team Lead; manual §8)
+      tags: [missions]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - { name: mission_id, in: path, required: true, schema: { type: string, format: uuid } }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [status]
+              properties:
+                status:
+                  type: string
+                  enum: [pending, mobilizing, active, waiting, returning, closed, cancelled]
+      responses:
+        "200":
+          description: Updated mission
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Mission" }
 components:
   securitySchemes:
     bearerAuth:
@@ -160,6 +298,41 @@ components:
         latitude: { type: number, nullable: true }
         longitude: { type: number, nullable: true }
         distance_m: { type: number }
+    Alert:
+      type: object
+      properties:
+        id: { type: string, format: uuid }
+        incident_id: { type: string, format: uuid }
+        user_id: { type: string, format: uuid }
+        alert_type: { type: string }
+        status: { type: string, enum: [sent, responded, timeout] }
+        response: { type: string, enum: [yes, no, need_details, timeout], nullable: true }
+        sent_at: { type: string, format: date-time }
+        responded_at: { type: string, format: date-time, nullable: true }
+        expiry_at: { type: string, format: date-time, nullable: true }
+    MissionMember:
+      type: object
+      properties:
+        user_id: { type: string, format: uuid }
+        role_in_mission: { type: string }
+        joined_at: { type: string, format: date-time }
+        left_at: { type: string, format: date-time, nullable: true }
+        live_location_enabled: { type: boolean }
+    Mission:
+      type: object
+      properties:
+        id: { type: string, format: uuid }
+        incident_id: { type: string, format: uuid }
+        lead_user_id: { type: string, format: uuid, nullable: true }
+        status:
+          type: string
+          enum: [pending, mobilizing, active, waiting, returning, closed, cancelled]
+        started_at: { type: string, format: date-time, nullable: true }
+        closed_at: { type: string, format: date-time, nullable: true }
+        created_at: { type: string, format: date-time }
+        members:
+          type: array
+          items: { $ref: "#/components/schemas/MissionMember" }
     Incident:
       type: object
       properties:

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -15,10 +15,17 @@ Implemented (manual §27 priorities 1–6):
 - **Geospatial responder search** — `GET /incidents/{id}/candidates` finds nearby
   verified responders within the incident radius (PostGIS `ST_DWithin`), ordered by
   distance, filterable by skills.
+- **Alerting** (§9) — `POST /incidents/{id}/alerts` selects candidates and sends alerts
+  with priority-based expiry (§9.4), a reason requirement for high-priority incidents
+  (§22.1) and a per-dispatcher rate limit (§9.5); responders see `GET /alerts` and answer
+  via `POST /alerts/{id}/respond` (expired alerts read as `timeout` and cannot be answered).
+- **Mission creation** (§5.3) — `POST /incidents/{id}/create-mission` assigns a Team Lead
+  and enrolls responders who accepted; `GET /missions`, `GET /missions/{id}` (membership-
+  scoped) and `PATCH /missions/{id}` for status transitions (§8).
 - **Audit logging** — every high-risk action is recorded; `GET /admin/audit-logs`.
 
-Alerting, mission creation, the mission room (WebSocket), chat and live location are
-the next increments.
+The mission room (WebSocket), chat, tasks, live location and mission closure are the
+next increments.
 
 ## Local development
 

--- a/services/api/app/alerting.py
+++ b/services/api/app/alerting.py
@@ -1,0 +1,57 @@
+"""Alerting policy helpers (manual section 9).
+
+Holds the expiry policy (section 9.4), the per-dispatcher anti-abuse rate
+limit (section 9.5) and the effective-status derivation that turns an
+unanswered, expired alert into a timeout (section 9.4 / 21.1).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .models import Alert, AuditLog
+
+# Expiry per incident priority (manual section 9.4).
+ALERT_TTL_MINUTES: dict[str, int] = {"low": 30, "medium": 15, "high": 5}
+DEFAULT_TTL_MINUTES = 15
+
+# Anti-abuse: a dispatcher may launch at most this many alert campaigns per
+# window (manual section 9.5 "Rate limits per dispatcher").
+RATE_LIMIT_CAMPAIGNS = 10
+RATE_LIMIT_WINDOW_SECONDS = 60
+
+ALERT_SEND_ACTION = "alert.send"
+
+
+def expiry_for_priority(priority: str, *, now: datetime | None = None) -> datetime:
+    now = now or datetime.now(UTC)
+    minutes = ALERT_TTL_MINUTES.get(priority, DEFAULT_TTL_MINUTES)
+    return now + timedelta(minutes=minutes)
+
+
+def effective_status(alert: Alert, *, now: datetime | None = None) -> str:
+    """An unanswered alert past its expiry reads as ``timeout``."""
+    now = now or datetime.now(UTC)
+    if alert.responded_at is None and alert.expiry_at is not None and now >= alert.expiry_at:
+        return "timeout"
+    return alert.status
+
+
+def is_expired(alert: Alert, *, now: datetime | None = None) -> bool:
+    now = now or datetime.now(UTC)
+    return alert.expiry_at is not None and now >= alert.expiry_at
+
+
+async def recent_campaign_count(session: AsyncSession, actor_user_id, *, now=None) -> int:
+    """Count this dispatcher's alert campaigns within the rate-limit window."""
+    now = now or datetime.now(UTC)
+    since = now - timedelta(seconds=RATE_LIMIT_WINDOW_SECONDS)
+    stmt = select(func.count()).select_from(AuditLog).where(
+        AuditLog.actor_user_id == actor_user_id,
+        AuditLog.action == ALERT_SEND_ACTION,
+        AuditLog.timestamp >= since,
+    )
+    return int((await session.execute(stmt)).scalar_one())

--- a/services/api/app/api/alerts.py
+++ b/services/api/app/api/alerts.py
@@ -1,27 +1,111 @@
-"""Alert endpoints (manual section 14.1).
+"""Alert endpoints (manual sections 9.3, 9.4, 14.1).
 
-Skeleton stubs — see :mod:`app.api.incidents` for the convention.
+Responders see their own alerts and respond Yes / No / Need details. An
+alert past its expiry reads as a timeout and can no longer be answered
+(manual section 9.4).
 """
 
 from __future__ import annotations
 
-from fastapi import APIRouter, status
+import uuid
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..alerting import effective_status, is_expired
+from ..audit import record_audit
+from ..db import get_session
+from ..deps import get_current_user
+from ..enums import AlertResponse, AlertType, UserRole
+from ..models import Alert, User
+from ..schemas import AlertOut, AlertRespondRequest
 
 router = APIRouter(prefix="/alerts", tags=["alerts"])
 
-_NOT_IMPLEMENTED = "Not implemented in the skeleton; see manual section 27."
+_STAFF_ROLES = {UserRole.PLATFORM_ADMIN, UserRole.ORG_ADMIN, UserRole.DISPATCHER, UserRole.AUDITOR}
 
 
-@router.get("")
-async def list_alerts() -> list[dict]:
-    return []
+def _alert_out(alert: Alert) -> AlertOut:
+    return AlertOut(
+        id=alert.id,
+        incident_id=alert.incident_id,
+        user_id=alert.user_id,
+        alert_type=AlertType(alert.alert_type),
+        status=effective_status(alert),
+        response=AlertResponse(alert.response) if alert.response else None,
+        sent_at=alert.sent_at,
+        responded_at=alert.responded_at,
+        expiry_at=alert.expiry_at,
+    )
 
 
-@router.get("/{alert_id}", status_code=status.HTTP_501_NOT_IMPLEMENTED)
-async def get_alert(alert_id: str) -> dict[str, str]:
-    return {"detail": _NOT_IMPLEMENTED}
+@router.get("", response_model=list[AlertOut])
+async def list_alerts(
+    user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+    limit: int = Query(default=50, ge=1, le=200),
+) -> list[AlertOut]:
+    """List the current user's alerts (their responder inbox)."""
+    stmt = (
+        select(Alert)
+        .where(Alert.user_id == user.id)
+        .order_by(Alert.sent_at.desc())
+        .limit(limit)
+    )
+    alerts = (await session.execute(stmt)).scalars().all()
+    return [_alert_out(a) for a in alerts]
 
 
-@router.post("/{alert_id}/respond", status_code=status.HTTP_501_NOT_IMPLEMENTED)
-async def respond_to_alert(alert_id: str) -> dict[str, str]:
-    return {"detail": _NOT_IMPLEMENTED}
+@router.get("/{alert_id}", response_model=AlertOut)
+async def get_alert(
+    alert_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> AlertOut:
+    alert = await session.get(Alert, alert_id)
+    if alert is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Alert not found")
+    if alert.user_id != user.id and UserRole(user.role) not in _STAFF_ROLES:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not your alert")
+    return _alert_out(alert)
+
+
+@router.post("/{alert_id}/respond", response_model=AlertOut)
+async def respond_to_alert(
+    alert_id: uuid.UUID,
+    payload: AlertRespondRequest,
+    request: Request,
+    user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> AlertOut:
+    """Record the recipient's response (manual section 9.3)."""
+    alert = await session.get(Alert, alert_id)
+    if alert is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Alert not found")
+    if alert.user_id != user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Only the recipient can respond"
+        )
+    if is_expired(alert) and alert.responded_at is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail="Alert has expired"
+        )
+
+    alert.response = AlertResponse(payload.response)
+    alert.responded_at = datetime.now(UTC)
+    alert.status = "responded"
+
+    await record_audit(
+        session,
+        action="alert.respond",
+        actor_user_id=user.id,
+        entity_type="alert",
+        entity_id=alert.id,
+        request=request,
+        metadata={"response": payload.response},
+    )
+    await session.commit()
+    await session.refresh(alert)
+    return _alert_out(alert)

--- a/services/api/app/api/incidents.py
+++ b/services/api/app/api/incidents.py
@@ -13,20 +13,31 @@ from datetime import UTC, datetime
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.sql.functions import func
 
+from ..alerting import (
+    ALERT_SEND_ACTION,
+    RATE_LIMIT_CAMPAIGNS,
+    expiry_for_priority,
+    recent_campaign_count,
+)
 from ..audit import record_audit
 from ..db import get_session
 from ..deps import get_current_user, require_dispatcher
-from ..enums import IncidentStatus, VerificationStatus
+from ..enums import AlertResponse, IncidentStatus, MissionStatus, VerificationStatus
 from ..geo import latitude_of, longitude_of, make_point
-from ..models import Incident, Responder, User
+from ..models import Alert, Incident, Mission, MissionMember, User
+from ..queries import find_candidates
 from ..schemas import (
+    AlertSendRequest,
+    AlertSendResult,
     IncidentCreate,
     IncidentOut,
     IncidentUpdate,
+    MissionCreateRequest,
+    MissionOut,
     ResponderCandidate,
 )
+from .missions import mission_out
 
 router = APIRouter(prefix="/incidents", tags=["incidents"])
 
@@ -222,26 +233,15 @@ async def responder_candidates(
             detail="Incident has no centre point and radius to search within",
         )
 
-    center = make_point(lng, lat)
-    distance = func.ST_Distance(Responder.home_location, center)
-    stmt = (
-        select(
-            Responder,
-            distance.label("distance_m"),
-            latitude_of(Responder.home_location).label("lat"),
-            longitude_of(Responder.home_location).label("lng"),
-        )
-        .where(Responder.home_location.isnot(None))
-        .where(func.ST_DWithin(Responder.home_location, center, incident.radius_m))
-        .order_by(distance.asc())
-        .limit(limit)
+    rows = await find_candidates(
+        session,
+        longitude=lng,
+        latitude=lat,
+        radius_m=incident.radius_m,
+        verified_only=verified_only,
+        skills=skills,
+        limit=limit,
     )
-    if verified_only:
-        stmt = stmt.where(Responder.verification_status == VerificationStatus.VERIFIED.value)
-    if skills:
-        stmt = stmt.where(Responder.skills.op("&&")(skills))
-
-    rows = (await session.execute(stmt)).all()
     return [
         ResponderCandidate(
             id=r.id,
@@ -261,16 +261,180 @@ async def responder_candidates(
     ]
 
 
-# --- Stubs deferred to the next increment (alerting + mission creation) ----
+@router.post(
+    "/{incident_id}/alerts",
+    response_model=AlertSendResult,
+    status_code=status.HTTP_201_CREATED,
+)
+async def trigger_alerts(
+    incident_id: uuid.UUID,
+    payload: AlertSendRequest,
+    request: Request,
+    user: User = Depends(require_dispatcher),
+    session: AsyncSession = Depends(get_session),
+) -> AlertSendResult:
+    """Alert nearby responders for an incident (manual sections 5.2, 9).
 
-_NOT_IMPLEMENTED = "Not implemented in this increment; see manual section 27."
+    Selects candidates by proximity/skills, creates one alert per recipient
+    with a priority-based expiry, and moves the incident to ``alerting``.
+    """
+    incident, lat, lng = await _load_incident(session, incident_id)
+    if incident.status in {IncidentStatus.CLOSED, IncidentStatus.CANCELLED}:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Incident is not active")
+    if lat is None or lng is None or incident.radius_m is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Incident has no centre point and radius to alert within",
+        )
+    # High-priority alerts must carry a reason (manual section 22.1).
+    if incident.priority == "high" and not (payload.reason and payload.reason.strip()):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="A reason is required for high-priority alerts",
+        )
+
+    # Anti-abuse rate limit per dispatcher (manual section 9.5).
+    if await recent_campaign_count(session, user.id) >= RATE_LIMIT_CAMPAIGNS:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Alert rate limit exceeded; please wait before sending more",
+        )
+
+    rows = await find_candidates(
+        session,
+        longitude=lng,
+        latitude=lat,
+        radius_m=incident.radius_m,
+        verified_only=payload.verified_only,
+        skills=payload.skills or None,
+        limit=payload.limit,
+    )
+
+    # Skip responders who already have an outstanding alert for this incident.
+    existing = (
+        await session.execute(
+            select(Alert.user_id).where(
+                Alert.incident_id == incident_id, Alert.status == "sent"
+            )
+        )
+    ).scalars().all()
+    already = set(existing)
+
+    expiry = expiry_for_priority(incident.priority)
+    created: list[Alert] = []
+    for responder, *_ in rows:
+        if responder.user_id in already:
+            continue
+        alert = Alert(
+            incident_id=incident_id,
+            user_id=responder.user_id,
+            alert_type=payload.alert_type,
+            status="sent",
+            expiry_at=expiry,
+        )
+        session.add(alert)
+        created.append(alert)
+
+    if incident.status != IncidentStatus.ALERTING:
+        incident.status = IncidentStatus.ALERTING
+    await session.flush()
+
+    await record_audit(
+        session,
+        action=ALERT_SEND_ACTION,
+        actor_user_id=user.id,
+        entity_type="incident",
+        entity_id=incident_id,
+        request=request,
+        metadata={
+            "alert_type": payload.alert_type,
+            "recipients": len(created),
+            "reason": payload.reason,
+        },
+    )
+    await session.commit()
+
+    return AlertSendResult(
+        incident_id=incident_id,
+        alert_type=payload.alert_type,
+        expiry_at=expiry,
+        recipients=len(created),
+        alert_ids=[a.id for a in created],
+    )
 
 
-@router.post("/{incident_id}/alerts", status_code=status.HTTP_501_NOT_IMPLEMENTED)
-async def trigger_alerts(incident_id: uuid.UUID) -> dict[str, str]:
-    return {"detail": _NOT_IMPLEMENTED}
+@router.post(
+    "/{incident_id}/create-mission",
+    response_model=MissionOut,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_mission(
+    incident_id: uuid.UUID,
+    payload: MissionCreateRequest,
+    request: Request,
+    user: User = Depends(require_dispatcher),
+    session: AsyncSession = Depends(get_session),
+) -> MissionOut:
+    """Create a mission from an incident and assign an optional Team Lead.
 
+    Responders who accepted an alert for the incident are added as mission
+    members (manual section 5.3).
+    """
+    incident, _lat, _lng = await _load_incident(session, incident_id)
+    if incident.status in {IncidentStatus.CLOSED, IncidentStatus.CANCELLED}:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Incident is not active")
 
-@router.post("/{incident_id}/create-mission", status_code=status.HTTP_501_NOT_IMPLEMENTED)
-async def create_mission(incident_id: uuid.UUID) -> dict[str, str]:
-    return {"detail": _NOT_IMPLEMENTED}
+    if payload.lead_user_id is not None:
+        lead = await session.get(User, payload.lead_user_id)
+        if lead is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Lead user not found")
+
+    mission = Mission(
+        incident_id=incident_id,
+        lead_user_id=payload.lead_user_id,
+        status=MissionStatus.PENDING,
+    )
+    session.add(mission)
+    await session.flush()
+
+    member_user_ids: set[uuid.UUID] = set()
+    if payload.lead_user_id is not None:
+        session.add(
+            MissionMember(
+                mission_id=mission.id,
+                user_id=payload.lead_user_id,
+                role_in_mission="team_lead",
+            )
+        )
+        member_user_ids.add(payload.lead_user_id)
+
+    if payload.auto_add_accepted:
+        accepted = (
+            await session.execute(
+                select(Alert.user_id).where(
+                    Alert.incident_id == incident_id, Alert.response == AlertResponse.YES
+                )
+            )
+        ).scalars().all()
+        for accepted_user in accepted:
+            if accepted_user in member_user_ids:
+                continue
+            session.add(
+                MissionMember(
+                    mission_id=mission.id, user_id=accepted_user, role_in_mission="responder"
+                )
+            )
+            member_user_ids.add(accepted_user)
+
+    incident.status = IncidentStatus.MISSION_CREATED
+    await record_audit(
+        session,
+        action="mission.create",
+        actor_user_id=user.id,
+        entity_type="mission",
+        entity_id=mission.id,
+        request=request,
+        metadata={"incident_id": str(incident_id), "members": len(member_user_ids)},
+    )
+    await session.commit()
+    return await mission_out(session, mission.id)

--- a/services/api/app/api/missions.py
+++ b/services/api/app/api/missions.py
@@ -1,47 +1,177 @@
-"""Mission endpoints (manual section 14.1).
+"""Mission endpoints (manual sections 5.3, 5.4, 8, 14.1).
 
-Skeleton stubs — see :mod:`app.api.incidents` for the convention.
+Implements mission listing, retrieval and status transitions. Membership
+governs visibility for non-staff roles. The mission room (WebSocket), chat,
+tasks, live location and closure land in later increments and remain stubs.
 """
 
 from __future__ import annotations
 
-from fastapi import APIRouter, status
+import uuid
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..audit import record_audit
+from ..db import get_session
+from ..deps import get_current_user
+from ..enums import MissionStatus, UserRole
+from ..models import Mission, MissionMember, User
+from ..schemas import MissionMemberOut, MissionOut, MissionUpdate
 
 router = APIRouter(prefix="/missions", tags=["missions"])
 
-_NOT_IMPLEMENTED = "Not implemented in the skeleton; see manual section 27."
+# Roles that may see and manage every mission (manual section 6).
+_STAFF_ROLES = {
+    UserRole.PLATFORM_ADMIN,
+    UserRole.ORG_ADMIN,
+    UserRole.DISPATCHER,
+    UserRole.AUDITOR,
+}
 
 
-@router.get("")
-async def list_missions() -> list[dict]:
-    return []
+async def mission_out(session: AsyncSession, mission_id: uuid.UUID) -> MissionOut:
+    """Serialize a mission with its current members."""
+    mission = await session.get(Mission, mission_id)
+    if mission is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Mission not found")
+    members = (
+        await session.execute(
+            select(MissionMember).where(MissionMember.mission_id == mission_id)
+        )
+    ).scalars().all()
+    return MissionOut(
+        id=mission.id,
+        incident_id=mission.incident_id,
+        lead_user_id=mission.lead_user_id,
+        status=MissionStatus(mission.status),
+        started_at=mission.started_at,
+        closed_at=mission.closed_at,
+        created_at=mission.created_at,
+        members=[
+            MissionMemberOut(
+                user_id=m.user_id,
+                role_in_mission=m.role_in_mission,
+                joined_at=m.joined_at,
+                left_at=m.left_at,
+                live_location_enabled=m.live_location_enabled,
+            )
+            for m in members
+        ],
+    )
 
 
-@router.get("/{mission_id}", status_code=status.HTTP_501_NOT_IMPLEMENTED)
-async def get_mission(mission_id: str) -> dict[str, str]:
-    return {"detail": _NOT_IMPLEMENTED}
+async def _is_member(session: AsyncSession, mission_id: uuid.UUID, user_id: uuid.UUID) -> bool:
+    found = await session.execute(
+        select(MissionMember.id).where(
+            MissionMember.mission_id == mission_id, MissionMember.user_id == user_id
+        )
+    )
+    return found.first() is not None
+
+
+@router.get("", response_model=list[MissionOut])
+async def list_missions(
+    user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+    limit: int = Query(default=50, ge=1, le=200),
+) -> list[MissionOut]:
+    stmt = select(Mission.id).order_by(Mission.created_at.desc()).limit(limit)
+    if UserRole(user.role) not in _STAFF_ROLES:
+        # Non-staff see only missions they lead or belong to.
+        member_missions = select(MissionMember.mission_id).where(
+            MissionMember.user_id == user.id
+        )
+        stmt = stmt.where(
+            (Mission.lead_user_id == user.id) | (Mission.id.in_(member_missions))
+        )
+    ids = (await session.execute(stmt)).scalars().all()
+    return [await mission_out(session, mid) for mid in ids]
+
+
+@router.get("/{mission_id}", response_model=MissionOut)
+async def get_mission(
+    mission_id: uuid.UUID,
+    user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> MissionOut:
+    mission = await session.get(Mission, mission_id)
+    if mission is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Mission not found")
+    if UserRole(user.role) not in _STAFF_ROLES:
+        is_member = await _is_member(session, mission_id, user.id)
+        if mission.lead_user_id != user.id and not is_member:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Not a mission member"
+            )
+    return await mission_out(session, mission_id)
+
+
+@router.patch("/{mission_id}", response_model=MissionOut)
+async def update_mission(
+    mission_id: uuid.UUID,
+    payload: MissionUpdate,
+    request: Request,
+    user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> MissionOut:
+    """Update mission status. Allowed for staff or the assigned Team Lead."""
+    mission = await session.get(Mission, mission_id)
+    if mission is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Mission not found")
+
+    is_lead = mission.lead_user_id == user.id
+    if UserRole(user.role) not in _STAFF_ROLES and not is_lead:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only staff or the Team Lead can update the mission",
+        )
+
+    previous = mission.status
+    mission.status = payload.status
+    if payload.status == MissionStatus.ACTIVE and mission.started_at is None:
+        mission.started_at = datetime.now(UTC)
+
+    await record_audit(
+        session,
+        action="mission.status_changed",
+        actor_user_id=user.id,
+        entity_type="mission",
+        entity_id=mission.id,
+        request=request,
+        metadata={"from": str(previous), "to": str(payload.status)},
+    )
+    await session.commit()
+    return await mission_out(session, mission_id)
+
+
+# --- Deferred to later increments (mission room, chat, tasks, closure) -----
+
+_NOT_IMPLEMENTED = "Not implemented in this increment; see manual section 27."
 
 
 @router.post("/{mission_id}/join", status_code=status.HTTP_501_NOT_IMPLEMENTED)
-async def join_mission(mission_id: str) -> dict[str, str]:
+async def join_mission(mission_id: uuid.UUID) -> dict[str, str]:
     return {"detail": _NOT_IMPLEMENTED}
 
 
 @router.post("/{mission_id}/leave", status_code=status.HTTP_501_NOT_IMPLEMENTED)
-async def leave_mission(mission_id: str) -> dict[str, str]:
+async def leave_mission(mission_id: uuid.UUID) -> dict[str, str]:
     return {"detail": _NOT_IMPLEMENTED}
 
 
 @router.post("/{mission_id}/close", status_code=status.HTTP_501_NOT_IMPLEMENTED)
-async def close_mission(mission_id: str) -> dict[str, str]:
+async def close_mission(mission_id: uuid.UUID) -> dict[str, str]:
     return {"detail": _NOT_IMPLEMENTED}
 
 
 @router.get("/{mission_id}/messages")
-async def list_messages(mission_id: str) -> list[dict]:
+async def list_messages(mission_id: uuid.UUID) -> list[dict]:
     return []
 
 
 @router.get("/{mission_id}/tasks")
-async def list_tasks(mission_id: str) -> list[dict]:
+async def list_tasks(mission_id: uuid.UUID) -> list[dict]:
     return []

--- a/services/api/app/queries.py
+++ b/services/api/app/queries.py
@@ -1,0 +1,52 @@
+"""Reusable query helpers.
+
+Geospatial responder candidate selection (manual section 9.1) is shared by
+the incident candidates endpoint and the alert-send flow.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import Row, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.functions import func
+
+from .enums import VerificationStatus
+from .geo import latitude_of, longitude_of, make_point
+from .models import Responder
+
+
+async def find_candidates(
+    session: AsyncSession,
+    *,
+    longitude: float,
+    latitude: float,
+    radius_m: int,
+    verified_only: bool = True,
+    skills: list[str] | None = None,
+    limit: int = 50,
+) -> list[Row]:
+    """Return responder rows within ``radius_m`` of the point, nearest first.
+
+    Each row is ``(Responder, distance_m, latitude, longitude)``. Selection
+    mirrors manual section 9.1: proximity, verification status and skills.
+    """
+    center = make_point(longitude, latitude)
+    distance = func.ST_Distance(Responder.home_location, center)
+    stmt = (
+        select(
+            Responder,
+            distance.label("distance_m"),
+            latitude_of(Responder.home_location).label("lat"),
+            longitude_of(Responder.home_location).label("lng"),
+        )
+        .where(Responder.home_location.isnot(None))
+        .where(func.ST_DWithin(Responder.home_location, center, radius_m))
+        .order_by(distance.asc())
+        .limit(limit)
+    )
+    if verified_only:
+        stmt = stmt.where(Responder.verification_status == VerificationStatus.VERIFIED.value)
+    if skills:
+        stmt = stmt.where(Responder.skills.op("&&")(skills))
+
+    return list((await session.execute(stmt)).all())

--- a/services/api/app/schemas.py
+++ b/services/api/app/schemas.py
@@ -8,7 +8,14 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
-from .enums import IncidentStatus, UserRole, VerificationStatus
+from .enums import (
+    AlertResponse,
+    AlertType,
+    IncidentStatus,
+    MissionStatus,
+    UserRole,
+    VerificationStatus,
+)
 
 Priority = Literal["low", "medium", "high"]
 
@@ -113,3 +120,72 @@ class ResponderCandidate(ResponderOut):
     """A responder matched by the alert candidate search, with distance."""
 
     distance_m: float
+
+
+# --- Alerts ---------------------------------------------------------------
+
+
+class AlertSendRequest(BaseModel):
+    alert_type: AlertType = AlertType.AVAILABILITY_REQUEST
+    # Required for high-priority incidents (manual section 22.1).
+    reason: str | None = Field(default=None, max_length=500)
+    verified_only: bool = True
+    skills: list[str] = Field(default_factory=list)
+    limit: int = Field(default=100, ge=1, le=500)
+
+
+class AlertSendResult(BaseModel):
+    incident_id: uuid.UUID
+    alert_type: AlertType
+    expiry_at: datetime
+    recipients: int
+    alert_ids: list[uuid.UUID]
+
+
+class AlertOut(BaseModel):
+    id: uuid.UUID
+    incident_id: uuid.UUID
+    user_id: uuid.UUID
+    alert_type: AlertType
+    status: str
+    response: AlertResponse | None
+    sent_at: datetime
+    responded_at: datetime | None
+    expiry_at: datetime | None
+
+
+class AlertRespondRequest(BaseModel):
+    # Timeout is system-assigned, not a user response.
+    response: Literal["yes", "no", "need_details"]
+
+
+# --- Missions -------------------------------------------------------------
+
+
+class MissionCreateRequest(BaseModel):
+    lead_user_id: uuid.UUID | None = None
+    # Add responders who accepted an alert for this incident as mission members.
+    auto_add_accepted: bool = True
+
+
+class MissionMemberOut(BaseModel):
+    user_id: uuid.UUID
+    role_in_mission: str
+    joined_at: datetime
+    left_at: datetime | None
+    live_location_enabled: bool
+
+
+class MissionOut(BaseModel):
+    id: uuid.UUID
+    incident_id: uuid.UUID
+    lead_user_id: uuid.UUID | None
+    status: MissionStatus
+    started_at: datetime | None
+    closed_at: datetime | None
+    created_at: datetime
+    members: list[MissionMemberOut]
+
+
+class MissionUpdate(BaseModel):
+    status: MissionStatus

--- a/services/api/tests/_util.py
+++ b/services/api/tests/_util.py
@@ -2,7 +2,16 @@
 
 from __future__ import annotations
 
+import os
+
 from httpx import AsyncClient
+from sqlalchemy import create_engine, text
+
+_TEST_DATABASE_URL = (
+    os.environ.get("TEST_DATABASE_URL")
+    or os.environ.get("DATABASE_URL")
+    or "postgresql+asyncpg://rescuenet:rescuenet@127.0.0.1:5432/rescuenet_test"
+)
 
 
 async def dev_login(client: AsyncClient, email: str, role: str) -> str:
@@ -14,3 +23,45 @@ async def dev_login(client: AsyncClient, email: str, role: str) -> str:
 
 def auth_header(token: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
+
+
+async def user_id(client: AsyncClient, token: str) -> str:
+    resp = await client.get("/me", headers=auth_header(token))
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+async def make_responder(
+    client: AsyncClient,
+    admin_token: str,
+    *,
+    email: str,
+    lat: float,
+    lng: float,
+    verified: bool = True,
+    skills: list[str] | None = None,
+) -> str:
+    """Create a user + responder profile; return the user id."""
+    token = await dev_login(client, email, "responder")
+    uid = await user_id(client, token)
+    resp = await client.post(
+        "/responders",
+        headers=auth_header(admin_token),
+        json={
+            "user_id": uid,
+            "latitude": lat,
+            "longitude": lng,
+            "verification_status": "verified" if verified else "unverified",
+            "skills": skills or [],
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return uid
+
+
+def execute_sql(sql: str, **params: object) -> None:
+    """Run a statement against the test database (for test setup only)."""
+    engine = create_engine(_TEST_DATABASE_URL.replace("+asyncpg", "+psycopg2"))
+    with engine.begin() as conn:
+        conn.execute(text(sql), params)
+    engine.dispose()

--- a/services/api/tests/test_alerting_unit.py
+++ b/services/api/tests/test_alerting_unit.py
@@ -1,0 +1,41 @@
+"""Unit tests for alerting policy helpers (no database required)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from app.alerting import (
+    ALERT_TTL_MINUTES,
+    effective_status,
+    expiry_for_priority,
+    is_expired,
+)
+from app.models import Alert
+
+
+def test_expiry_matches_priority_policy() -> None:
+    now = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    assert expiry_for_priority("high", now=now) == now + timedelta(minutes=5)
+    assert expiry_for_priority("medium", now=now) == now + timedelta(minutes=15)
+    assert expiry_for_priority("low", now=now) == now + timedelta(minutes=30)
+    # Unknown priority falls back to the medium default.
+    assert expiry_for_priority("weird", now=now) == now + timedelta(
+        minutes=ALERT_TTL_MINUTES["medium"]
+    )
+
+
+def test_effective_status_times_out_unanswered_expired() -> None:
+    now = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    alert = Alert(status="sent", expiry_at=now - timedelta(minutes=1), responded_at=None)
+    assert effective_status(alert, now=now) == "timeout"
+    assert is_expired(alert, now=now) is True
+
+
+def test_effective_status_keeps_answered_alert() -> None:
+    now = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    alert = Alert(
+        status="responded",
+        expiry_at=now - timedelta(minutes=1),
+        responded_at=now - timedelta(minutes=2),
+    )
+    assert effective_status(alert, now=now) == "responded"

--- a/services/api/tests/test_alerts_api.py
+++ b/services/api/tests/test_alerts_api.py
@@ -1,0 +1,155 @@
+"""Integration tests for the alerting flow (requires a database)."""
+
+from __future__ import annotations
+
+from httpx import AsyncClient
+
+from ._util import auth_header, dev_login, execute_sql, make_responder
+
+
+async def _incident_with_area(client: AsyncClient, token: str, *, priority: str = "medium") -> str:
+    resp = await client.post(
+        "/incidents",
+        headers=auth_header(token),
+        json={
+            "title": "Alerting incident",
+            "priority": priority,
+            "latitude": 45.0,
+            "longitude": 25.0,
+            "radius_m": 50000,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def test_send_alerts_and_respond(client: AsyncClient) -> None:
+    admin = await dev_login(client, "a@example.org", "platform_admin")
+    dispatcher = await dev_login(client, "d@example.org", "dispatcher")
+    responder_token = await dev_login(client, "near@example.org", "responder")
+    responder_id = await make_responder(
+        client, admin, email="near@example.org", lat=45.05, lng=25.0
+    )
+
+    incident_id = await _incident_with_area(client, dispatcher)
+    send = await client.post(
+        f"/incidents/{incident_id}/alerts",
+        headers=auth_header(dispatcher),
+        json={"alert_type": "availability_request"},
+    )
+    assert send.status_code == 201, send.text
+    assert send.json()["recipients"] == 1
+
+    # Incident moved to "alerting".
+    incident = await client.get(f"/incidents/{incident_id}", headers=auth_header(dispatcher))
+    assert incident.json()["status"] == "alerting"
+
+    # The responder sees the alert in their inbox.
+    inbox = await client.get("/alerts", headers=auth_header(responder_token))
+    assert inbox.status_code == 200
+    alerts = inbox.json()
+    assert len(alerts) == 1
+    assert alerts[0]["status"] == "sent"
+    alert_id = alerts[0]["id"]
+    assert alerts[0]["user_id"] == responder_id
+
+    # And can accept it.
+    respond = await client.post(
+        f"/alerts/{alert_id}/respond",
+        headers=auth_header(responder_token),
+        json={"response": "yes"},
+    )
+    assert respond.status_code == 200
+    assert respond.json()["response"] == "yes"
+    assert respond.json()["status"] == "responded"
+
+
+async def test_resend_skips_already_alerted(client: AsyncClient) -> None:
+    admin = await dev_login(client, "a2@example.org", "platform_admin")
+    dispatcher = await dev_login(client, "d2@example.org", "dispatcher")
+    await make_responder(client, admin, email="r2@example.org", lat=45.01, lng=25.0)
+    incident_id = await _incident_with_area(client, dispatcher)
+
+    first = await client.post(
+        f"/incidents/{incident_id}/alerts", headers=auth_header(dispatcher), json={}
+    )
+    assert first.json()["recipients"] == 1
+    second = await client.post(
+        f"/incidents/{incident_id}/alerts", headers=auth_header(dispatcher), json={}
+    )
+    assert second.json()["recipients"] == 0
+
+
+async def test_high_priority_requires_reason(client: AsyncClient) -> None:
+    admin = await dev_login(client, "a3@example.org", "platform_admin")
+    dispatcher = await dev_login(client, "d3@example.org", "dispatcher")
+    await make_responder(client, admin, email="r3@example.org", lat=45.01, lng=25.0)
+    incident_id = await _incident_with_area(client, dispatcher, priority="high")
+
+    no_reason = await client.post(
+        f"/incidents/{incident_id}/alerts", headers=auth_header(dispatcher), json={}
+    )
+    assert no_reason.status_code == 422
+
+    with_reason = await client.post(
+        f"/incidents/{incident_id}/alerts",
+        headers=auth_header(dispatcher),
+        json={"reason": "Person trapped, urgent"},
+    )
+    assert with_reason.status_code == 201
+
+
+async def test_expired_alert_cannot_be_answered(client: AsyncClient) -> None:
+    admin = await dev_login(client, "a4@example.org", "platform_admin")
+    dispatcher = await dev_login(client, "d4@example.org", "dispatcher")
+    responder_token = await dev_login(client, "r4@example.org", "responder")
+    await make_responder(client, admin, email="r4@example.org", lat=45.01, lng=25.0)
+    incident_id = await _incident_with_area(client, dispatcher)
+
+    send = await client.post(
+        f"/incidents/{incident_id}/alerts", headers=auth_header(dispatcher), json={}
+    )
+    alert_id = send.json()["alert_ids"][0]
+
+    # Backdate expiry to simulate timeout.
+    execute_sql(
+        "UPDATE alerts SET expiry_at = now() - interval '1 hour' WHERE id = CAST(:id AS uuid)",
+        id=alert_id,
+    )
+
+    inbox = await client.get("/alerts", headers=auth_header(responder_token))
+    assert inbox.json()[0]["status"] == "timeout"
+
+    respond = await client.post(
+        f"/alerts/{alert_id}/respond",
+        headers=auth_header(responder_token),
+        json={"response": "yes"},
+    )
+    assert respond.status_code == 409
+
+
+async def test_only_recipient_can_respond(client: AsyncClient) -> None:
+    admin = await dev_login(client, "a5@example.org", "platform_admin")
+    dispatcher = await dev_login(client, "d5@example.org", "dispatcher")
+    await make_responder(client, admin, email="r5@example.org", lat=45.01, lng=25.0)
+    other = await dev_login(client, "other@example.org", "responder")
+    incident_id = await _incident_with_area(client, dispatcher)
+    send = await client.post(
+        f"/incidents/{incident_id}/alerts", headers=auth_header(dispatcher), json={}
+    )
+    alert_id = send.json()["alert_ids"][0]
+
+    resp = await client.post(
+        f"/alerts/{alert_id}/respond", headers=auth_header(other), json={"response": "no"}
+    )
+    assert resp.status_code == 403
+
+
+async def test_responder_cannot_send_alerts(client: AsyncClient) -> None:
+    dispatcher = await dev_login(client, "d6@example.org", "dispatcher")
+    responder = await dev_login(client, "r6@example.org", "responder")
+    incident_id = await _incident_with_area(client, dispatcher)
+    resp = await client.post(
+        f"/incidents/{incident_id}/alerts", headers=auth_header(responder), json={}
+    )
+    assert resp.status_code == 403

--- a/services/api/tests/test_missions_api.py
+++ b/services/api/tests/test_missions_api.py
@@ -1,0 +1,124 @@
+"""Integration tests for mission creation and management (requires a database)."""
+
+from __future__ import annotations
+
+from httpx import AsyncClient
+
+from ._util import auth_header, dev_login, make_responder, user_id
+
+
+async def _alerted_incident(client: AsyncClient, dispatcher: str, admin: str) -> tuple[str, str]:
+    """Create an incident, alert one responder; return (incident_id, responder_token)."""
+    responder_token = await dev_login(client, "resp@example.org", "responder")
+    await make_responder(client, admin, email="resp@example.org", lat=45.02, lng=25.0)
+    incident_id = (
+        await client.post(
+            "/incidents",
+            headers=auth_header(dispatcher),
+            json={"title": "Mission", "latitude": 45.0, "longitude": 25.0, "radius_m": 50000},
+        )
+    ).json()["id"]
+    send = await client.post(
+        f"/incidents/{incident_id}/alerts", headers=auth_header(dispatcher), json={}
+    )
+    alert_id = send.json()["alert_ids"][0]
+    await client.post(
+        f"/alerts/{alert_id}/respond",
+        headers=auth_header(responder_token),
+        json={"response": "yes"},
+    )
+    return incident_id, responder_token
+
+
+async def test_create_mission_adds_accepted_and_lead(client: AsyncClient) -> None:
+    admin = await dev_login(client, "ma@example.org", "platform_admin")
+    dispatcher = await dev_login(client, "md@example.org", "dispatcher")
+    lead_token = await dev_login(client, "lead@example.org", "team_lead")
+    lead_id = await user_id(client, lead_token)
+
+    incident_id, responder_token = await _alerted_incident(client, dispatcher, admin)
+    responder_id = await user_id(client, responder_token)
+
+    create = await client.post(
+        f"/incidents/{incident_id}/create-mission",
+        headers=auth_header(dispatcher),
+        json={"lead_user_id": lead_id},
+    )
+    assert create.status_code == 201, create.text
+    mission = create.json()
+    assert mission["status"] == "pending"
+    assert mission["lead_user_id"] == lead_id
+
+    roles = {m["user_id"]: m["role_in_mission"] for m in mission["members"]}
+    assert roles.get(lead_id) == "team_lead"
+    assert roles.get(responder_id) == "responder"
+
+    # Incident transitioned to mission_created.
+    incident = await client.get(f"/incidents/{incident_id}", headers=auth_header(dispatcher))
+    assert incident.json()["status"] == "mission_created"
+
+
+async def test_mission_visibility(client: AsyncClient) -> None:
+    admin = await dev_login(client, "va@example.org", "platform_admin")
+    dispatcher = await dev_login(client, "vd@example.org", "dispatcher")
+    incident_id, responder_token = await _alerted_incident(client, dispatcher, admin)
+    mission_id = (
+        await client.post(
+            f"/incidents/{incident_id}/create-mission", headers=auth_header(dispatcher), json={}
+        )
+    ).json()["id"]
+
+    # Member responder can see it; a non-member responder cannot.
+    member_view = await client.get(f"/missions/{mission_id}", headers=auth_header(responder_token))
+    assert member_view.status_code == 200
+
+    outsider = await dev_login(client, "outsider@example.org", "responder")
+    outsider_view = await client.get(f"/missions/{mission_id}", headers=auth_header(outsider))
+    assert outsider_view.status_code == 403
+
+    # Listing reflects membership.
+    assert len((await client.get("/missions", headers=auth_header(responder_token))).json()) == 1
+    assert (await client.get("/missions", headers=auth_header(outsider))).json() == []
+    assert len((await client.get("/missions", headers=auth_header(dispatcher))).json()) == 1
+
+
+async def test_mission_status_update_permissions(client: AsyncClient) -> None:
+    admin = await dev_login(client, "sa@example.org", "platform_admin")
+    dispatcher = await dev_login(client, "sd@example.org", "dispatcher")
+    lead_token = await dev_login(client, "slead@example.org", "team_lead")
+    lead_id = await user_id(client, lead_token)
+    incident_id, _ = await _alerted_incident(client, dispatcher, admin)
+    mission_id = (
+        await client.post(
+            f"/incidents/{incident_id}/create-mission",
+            headers=auth_header(dispatcher),
+            json={"lead_user_id": lead_id},
+        )
+    ).json()["id"]
+
+    # Team lead can advance the mission; started_at gets set on activation.
+    activate = await client.patch(
+        f"/missions/{mission_id}", headers=auth_header(lead_token), json={"status": "active"}
+    )
+    assert activate.status_code == 200
+    assert activate.json()["status"] == "active"
+    assert activate.json()["started_at"] is not None
+
+    # An unrelated responder cannot.
+    outsider = await dev_login(client, "sout@example.org", "responder")
+    denied = await client.patch(
+        f"/missions/{mission_id}", headers=auth_header(outsider), json={"status": "closed"}
+    )
+    assert denied.status_code == 403
+
+
+async def test_create_mission_requires_dispatcher(client: AsyncClient) -> None:
+    dispatcher = await dev_login(client, "cd@example.org", "dispatcher")
+    responder = await dev_login(client, "cr@example.org", "responder")
+    incident_id = (
+        await client.post("/incidents", headers=auth_header(dispatcher), json={"title": "X"})
+    ).json()["id"]
+    resp = await client.post(
+        f"/incidents/{incident_id}/create-mission", headers=auth_header(responder), json={}
+    )
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary

Next backend increment — manual [§27](docs/project-manual.md) priorities **7 (alerting)** and **9 (mission creation)** — built on the auth/RBAC/incidents/audit foundation. Completes the spine of the operational flow: **incident → alert nearby responders → they accept → create a mission with a Team Lead**.

## What's implemented

**Alerting** (§9)
- `POST /incidents/{id}/alerts` — selects nearby candidates (shared geospatial query extracted to `app/queries.py`, reused by the candidates endpoint) and creates one alert per recipient with a **priority-based expiry** (§9.4: high 5m / medium 15m / low 30m). Skips responders who already have an outstanding alert; moves the incident to `alerting`.
- **Anti-abuse** (§9.5, §22.1): dispatcher-only (RBAC), a **reason is required for high-priority** incidents, and a **per-dispatcher rate limit**.
- `GET /alerts` (responder inbox), `GET /alerts/{id}`, `POST /alerts/{id}/respond` with Yes / No / Need-details. Expired, unanswered alerts read as `timeout` and can no longer be answered (§9.4).

**Mission creation** (§5.3, §8)
- `POST /incidents/{id}/create-mission` — assigns an optional **Team Lead** and **enrolls responders who accepted** an alert; transitions the incident to `mission_created`.
- `GET /missions` and `GET /missions/{id}` are **membership-scoped** for non-staff; `PATCH /missions/{id}` updates status (staff or Team Lead), setting `started_at` on activation.

All four new actions are **audited** (`alert.send`, `alert.respond`, `mission.create`, `mission.status_changed`).

## Verification (run here against PostGIS 3.4)
- `ruff check .` → clean
- `pytest -q` → **33 passed** (alerting-policy unit tests + DB-backed integration: alert send/inbox/respond, expiry→timeout→409, RBAC, mission creation w/ auto-enrol + lead, visibility, status-change permissions)
- `alembic check` → no drift (no model changes this increment)
- App boots; OpenAPI contract (`packages/shared/openapi.yaml`) and API README updated.

## Scope / next
The mission room (WebSocket fan-out), chat, tasks, live location (consent-gated, mission-only) and mission closure remain documented `501` stubs — the next increment.

https://claude.ai/code/session_01GXFvogf9K1hthTKZbdxrYu

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXFvogf9K1hthTKZbdxrYu)_